### PR TITLE
Support optional proxy host

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ The script respects gitignore so it does not overwrite any files that are in you
 ## Usage
 
 ```bash
-./sync_to_server.sh source_directory remote_directory
+./sync_to_server.sh source_directory remote_directory [proxy_host]
 ```
 
 ## Prerequisites
@@ -17,13 +17,23 @@ The script respects gitignore so it does not overwrite any files that are in you
 - A `.gitignore` file in the source directory (optional).
 - A global gitignore file configured via `git config --global core.excludesfile` (optional).
 
-## How It Works
+## How it works
 
 1. Checks if the correct number of arguments are supplied.
 2. Sets source and destination directories from the command line arguments.
 3. Ensures `rsync` and `fswatch` are installed.
 4. Performs an initial sync using `rsync`.
 5. Watches for changes in the source directory and synchronizes them to the remote directory.
+
+### Proxy host
+
+The script supports synchronizing through an intermediate proxy/jump host when direct connection to the destination server is not possible (e.g., when the destination is behind a firewall or in a private network).
+
+To use a proxy host, add it as the third argument:
+
+```bash
+./sync_to_server.sh /path/to/source_directory user@remote:/path/to/destination_directory proxy_user@proxy_host
+```
 
 ## Example
 


### PR DESCRIPTION
This pull request includes updates to the `sync_to_server.sh` script to add support for an optional proxy host parameter. This allows the script to access devices through another device, i.e.:  
sender -> proxy -> destination

Enhancements to `sync_to_server.sh`:

* Updated the script to accept an optional third argument for the proxy host.
* Adjusted the `rsync_to_server` function to conditionally include the proxy host in the `rsync` command if it is provided.